### PR TITLE
Add start node support for GraphPanel

### DIFF
--- a/src/me/wphillips/fsmedit/GraphEditor.java
+++ b/src/me/wphillips/fsmedit/GraphEditor.java
@@ -11,10 +11,14 @@ public class GraphEditor {
             GraphPanel panel = new GraphPanel();
             Node a = new Node(100, 100, 30, "A");
             Node b = new Node(250, 100, 30, "B");
+            Node c = new Node(175, 200, 30, "C");
             panel.addNode(a);
             panel.addNode(b);
+            panel.addNode(c);
             panel.setStartNode(a);
             panel.addEdge(new Edge(a, b));
+            panel.addEdge(new Edge(b, c));
+            panel.addEdge(new Edge(c, a));
 
             frame.add(panel);
             frame.setSize(400, 300);

--- a/src/me/wphillips/fsmedit/GraphEditor.java
+++ b/src/me/wphillips/fsmedit/GraphEditor.java
@@ -13,6 +13,7 @@ public class GraphEditor {
             Node b = new Node(250, 100, 30, "B");
             panel.addNode(a);
             panel.addNode(b);
+            panel.setStartNode(a);
             panel.addEdge(new Edge(a, b));
 
             frame.add(panel);

--- a/src/me/wphillips/fsmedit/GraphPanel.java
+++ b/src/me/wphillips/fsmedit/GraphPanel.java
@@ -9,6 +9,7 @@ import java.util.List;
 public class GraphPanel extends JPanel {
     private final List<Node> nodes = new ArrayList<>();
     private final List<Edge> edges = new ArrayList<>();
+    private Node startNode;
 
     public void addNode(Node node) {
         nodes.add(node);
@@ -16,6 +17,11 @@ public class GraphPanel extends JPanel {
 
     public void addEdge(Edge edge) {
         edges.add(edge);
+    }
+
+    public void setStartNode(Node node) {
+        this.startNode = node;
+        repaint();
     }
 
     @Override
@@ -40,7 +46,11 @@ public class GraphPanel extends JPanel {
         int r = n.getRadius();
         int x = n.getX() - r;
         int y = n.getY() - r;
-        g2.setColor(Color.WHITE);
+        if (n == startNode) {
+            g2.setColor(new Color(144, 238, 144)); // light green
+        } else {
+            g2.setColor(Color.WHITE);
+        }
         g2.fillOval(x, y, 2 * r, 2 * r);
         g2.setColor(Color.BLACK);
         g2.drawOval(x, y, 2 * r, 2 * r);


### PR DESCRIPTION
## Summary
- support a start node in `GraphPanel`
- color the start node light green when drawn
- allow setting the start node
- mark node `A` as the start node in the demo

## Testing
- `javac -d bin src/me/wphillips/fsmedit/*.java`
- `java -cp bin me.wphillips.fsmedit.GraphEditor` *(fails: No X11 DISPLAY variable)*

------
https://chatgpt.com/codex/tasks/task_e_6840f0bc32348324902a4c1fca465606