### PR TITLE
Enable edge destination editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,4 @@ Finite state machine editor.
 ## Controls
 
 * **Ctrl + Drag** - Create a new edge from one node to another.
+* **Ctrl + Drag an edge** - Change its destination or drop on empty space to delete it.

--- a/src/me/wphillips/fsmedit/Edge.java
+++ b/src/me/wphillips/fsmedit/Edge.java
@@ -16,4 +16,11 @@ public class Edge {
     public Node getTo() {
         return to;
     }
+
+    /**
+     * Update the destination node for this edge.
+     */
+    public void setTo(Node to) {
+        this.to = to;
+    }
 }

--- a/src/me/wphillips/fsmedit/GraphPanel.java
+++ b/src/me/wphillips/fsmedit/GraphPanel.java
@@ -86,6 +86,8 @@ public class GraphPanel extends JPanel {
                     Node hit = getNodeAt(e.getX(), e.getY());
                     if (hit != null && hit != edgeStart) {
                         editingEdge.setTo(hit);
+                    } else {
+                        edges.remove(editingEdge);
                     }
                     editingEdge = null;
                     edgeStart = null;


### PR DESCRIPTION
## Summary
- allow changing an edge's destination node by ctrl-dragging the arrow end
- skip drawing the edge currently being edited
- highlight potential target nodes when editing
- expose a setter for `Edge.to`

## Testing
- `javac -d out $(find src -name '*.java')`

------
https://chatgpt.com/codex/tasks/task_e_685372b37bc08324859d1e81e4df01e5