### PR TITLE
Add position and metadata fields for nodes

### DIFF
--- a/src/me/wphillips/fsmedit/GraphPanel.java
+++ b/src/me/wphillips/fsmedit/GraphPanel.java
@@ -155,6 +155,9 @@ public class GraphPanel extends JPanel {
                     draggedNode.moveBy(dx, dy);
                     lastMouseX = e.getX();
                     lastMouseY = e.getY();
+                    if (propertiesPanel != null) {
+                        propertiesPanel.updatePositionFields();
+                    }
                     repaint();
                 }
             }

--- a/src/me/wphillips/fsmedit/Node.java
+++ b/src/me/wphillips/fsmedit/Node.java
@@ -5,11 +5,14 @@ import java.io.Serializable;
 
 public class Node implements Serializable {
     private static final long serialVersionUID = 1L;
+
     private int x;
     private int y;
     private int radius;
     private String label;
     private Color color;
+    /** Additional notes attached to the node. */
+    private String metadata;
 
     public Node(int x, int y, int radius, String label) {
         this(x, y, radius, label, Color.WHITE);
@@ -21,14 +24,25 @@ public class Node implements Serializable {
         this.radius = radius;
         this.label = label;
         this.color = color;
+        this.metadata = "";
     }
 
     public int getX() {
         return x;
     }
 
+    /** Set the x-coordinate of this node. */
+    public void setX(int x) {
+        this.x = x;
+    }
+
     public int getY() {
         return y;
+    }
+
+    /** Set the y-coordinate of this node. */
+    public void setY(int y) {
+        this.y = y;
     }
 
     public int getRadius() {
@@ -49,6 +63,16 @@ public class Node implements Serializable {
 
     public void setColor(Color color) {
         this.color = color;
+    }
+
+    /** Get additional metadata/notes for this node. */
+    public String getMetadata() {
+        return metadata;
+    }
+
+    /** Set metadata/notes for this node. */
+    public void setMetadata(String metadata) {
+        this.metadata = metadata;
     }
 
     /**

--- a/src/me/wphillips/fsmedit/NodePropertiesPanel.java
+++ b/src/me/wphillips/fsmedit/NodePropertiesPanel.java
@@ -54,7 +54,11 @@ public class NodePropertiesPanel extends JPanel {
             }
         });
         gbc.weightx = 1.0;
+        // Add a bit more bottom margin below the label field
+        gbc.insets = new Insets(2, 2, 6, 2);
         add(labelField, gbc);
+        // Restore default insets for subsequent rows
+        gbc.insets = new Insets(2, 2, 2, 2);
 
         // Position panel with X and Y side by side
         gbc.gridy++;

--- a/src/me/wphillips/fsmedit/NodePropertiesPanel.java
+++ b/src/me/wphillips/fsmedit/NodePropertiesPanel.java
@@ -160,6 +160,9 @@ public class NodePropertiesPanel extends JPanel {
     }
 
     public void setNode(Node node) {
+        if (this.node != null && this.node != node) {
+            commitPositionEdits();
+        }
         this.node = node;
         boolean visible = node != null;
         labelLabel.setVisible(visible);
@@ -199,6 +202,23 @@ public class NodePropertiesPanel extends JPanel {
         if (node != null) {
             xSpinner.setValue(node.getX());
             ySpinner.setValue(node.getY());
+        }
+    }
+
+    /**
+     * Commit any unconfirmed edits in the X and Y spinners back to the node.
+     */
+    private void commitPositionEdits() {
+        if (node != null) {
+            try {
+                xSpinner.commitEdit();
+                ySpinner.commitEdit();
+            } catch (java.text.ParseException ignored) {
+                // If the user entered invalid text, ignore and keep last value
+            }
+            node.setX((Integer) xSpinner.getValue());
+            node.setY((Integer) ySpinner.getValue());
+            graphPanel.repaint();
         }
     }
 }

--- a/src/me/wphillips/fsmedit/NodePropertiesPanel.java
+++ b/src/me/wphillips/fsmedit/NodePropertiesPanel.java
@@ -3,6 +3,8 @@ package me.wphillips.fsmedit;
 import javax.swing.*;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
 import javax.swing.border.CompoundBorder;
 import javax.swing.border.EmptyBorder;
 import java.awt.*;
@@ -10,8 +12,15 @@ import java.awt.*;
 public class NodePropertiesPanel extends JPanel {
     private final JLabel labelLabel;
     private final JTextField labelField;
+    private final JLabel xLabel;
+    private final JSpinner xSpinner;
+    private final JLabel yLabel;
+    private final JSpinner ySpinner;
     private final JLabel colorLabel;
     private final JButton colorButton;
+    private final JLabel metadataLabel;
+    private final JTextArea metadataArea;
+    private final JScrollPane metadataScroll;
     private final GraphPanel graphPanel;
     private Node node;
 
@@ -45,6 +54,48 @@ public class NodePropertiesPanel extends JPanel {
         });
         gbc.weightx = 1.0;
         add(labelField, gbc);
+
+        // X position
+        gbc.gridy++;
+        gbc.weightx = 0;
+        xLabel = new JLabel("X:");
+        add(xLabel, gbc);
+        gbc.gridy++;
+        xSpinner = new JSpinner(new SpinnerNumberModel(0, -10000, 10000, 1));
+        xSpinner.setEnabled(false);
+        xSpinner.addChangeListener(new ChangeListener() {
+            @Override
+            public void stateChanged(ChangeEvent e) {
+                if (node != null) {
+                    node.setX((Integer) xSpinner.getValue());
+                    graphPanel.repaint();
+                }
+            }
+        });
+        gbc.weightx = 1.0;
+        add(xSpinner, gbc);
+
+        // Y position
+        gbc.gridy++;
+        gbc.weightx = 0;
+        yLabel = new JLabel("Y:");
+        add(yLabel, gbc);
+        gbc.gridy++;
+        ySpinner = new JSpinner(new SpinnerNumberModel(0, -10000, 10000, 1));
+        ySpinner.setEnabled(false);
+        ySpinner.addChangeListener(new ChangeListener() {
+            @Override
+            public void stateChanged(ChangeEvent e) {
+                if (node != null) {
+                    node.setY((Integer) ySpinner.getValue());
+                    graphPanel.repaint();
+                }
+            }
+        });
+        gbc.weightx = 1.0;
+        add(ySpinner, gbc);
+
+        // Color
         gbc.gridy++;
         gbc.weightx = 0;
         colorLabel = new JLabel("Color:");
@@ -65,8 +116,35 @@ public class NodePropertiesPanel extends JPanel {
         });
         gbc.weightx = 1.0;
         add(colorButton, gbc);
+
+        // Metadata text area
+        gbc.gridy++;
+        gbc.weightx = 0;
+        metadataLabel = new JLabel("Metadata:");
+        add(metadataLabel, gbc);
+        gbc.gridy++;
+        metadataArea = new JTextArea(5, 10);
+        metadataArea.setLineWrap(true);
+        metadataArea.setWrapStyleWord(true);
+        metadataArea.setEnabled(false);
+        metadataArea.getDocument().addDocumentListener(new DocumentListener() {
+            public void insertUpdate(DocumentEvent e) { update(); }
+            public void removeUpdate(DocumentEvent e) { update(); }
+            public void changedUpdate(DocumentEvent e) { update(); }
+            private void update() {
+                if (node != null) {
+                    node.setMetadata(metadataArea.getText());
+                }
+            }
+        });
+        metadataScroll = new JScrollPane(metadataArea);
+        gbc.weightx = 1.0;
+        gbc.fill = GridBagConstraints.BOTH;
+        add(metadataScroll, gbc);
+
         gbc.weighty = 1;
         gbc.gridy++;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
         add(Box.createVerticalGlue(), gbc);
         setPreferredSize(new Dimension(180, 0));
 
@@ -79,16 +157,31 @@ public class NodePropertiesPanel extends JPanel {
         boolean visible = node != null;
         labelLabel.setVisible(visible);
         labelField.setVisible(visible);
+        xLabel.setVisible(visible);
+        xSpinner.setVisible(visible);
+        yLabel.setVisible(visible);
+        ySpinner.setVisible(visible);
         colorLabel.setVisible(visible);
         colorButton.setVisible(visible);
+        metadataLabel.setVisible(visible);
+        metadataScroll.setVisible(visible);
         labelField.setEnabled(visible);
+        xSpinner.setEnabled(visible);
+        ySpinner.setEnabled(visible);
         colorButton.setEnabled(visible);
+        metadataArea.setEnabled(visible);
         if (node == null) {
             labelField.setText("");
+            xSpinner.setValue(0);
+            ySpinner.setValue(0);
             colorButton.setBackground(null);
+            metadataArea.setText("");
         } else {
             labelField.setText(node.getLabel());
+            xSpinner.setValue(node.getX());
+            ySpinner.setValue(node.getY());
             colorButton.setBackground(node.getColor());
+            metadataArea.setText(node.getMetadata());
         }
         revalidate();
         repaint();

--- a/src/me/wphillips/fsmedit/NodePropertiesPanel.java
+++ b/src/me/wphillips/fsmedit/NodePropertiesPanel.java
@@ -8,6 +8,7 @@ import javax.swing.event.ChangeListener;
 import javax.swing.border.CompoundBorder;
 import javax.swing.border.EmptyBorder;
 import java.awt.*;
+import java.text.ParseException;
 
 public class NodePropertiesPanel extends JPanel {
     private final JLabel labelLabel;
@@ -16,6 +17,7 @@ public class NodePropertiesPanel extends JPanel {
     private final JSpinner xSpinner;
     private final JLabel yLabel;
     private final JSpinner ySpinner;
+    private final JPanel positionPanel;
     private final JLabel colorLabel;
     private final JButton colorButton;
     private final JLabel metadataLabel;
@@ -55,13 +57,15 @@ public class NodePropertiesPanel extends JPanel {
         gbc.weightx = 1.0;
         add(labelField, gbc);
 
-        // X position
+        // Position panel with X and Y side by side
         gbc.gridy++;
-        gbc.weightx = 0;
+        gbc.weightx = 1.0;
+        positionPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 2, 0));
+
         xLabel = new JLabel("X:");
-        add(xLabel, gbc);
-        gbc.gridy++;
+        positionPanel.add(xLabel);
         xSpinner = new JSpinner(new SpinnerNumberModel(0, -10000, 10000, 1));
+        xSpinner.setPreferredSize(new Dimension(60, xSpinner.getPreferredSize().height));
         xSpinner.setEnabled(false);
         xSpinner.addChangeListener(new ChangeListener() {
             @Override
@@ -72,16 +76,24 @@ public class NodePropertiesPanel extends JPanel {
                 }
             }
         });
-        gbc.weightx = 1.0;
-        add(xSpinner, gbc);
+        ((JFormattedTextField) ((JSpinner.DefaultEditor) xSpinner.getEditor()).getTextField()).getDocument().addDocumentListener(new DocumentListener() {
+            public void insertUpdate(DocumentEvent e) { commit(); }
+            public void removeUpdate(DocumentEvent e) { commit(); }
+            public void changedUpdate(DocumentEvent e) { commit(); }
+            private void commit() {
+                try {
+                    xSpinner.commitEdit();
+                } catch (ParseException ex) {
+                    return;
+                }
+            }
+        });
+        positionPanel.add(xSpinner);
 
-        // Y position
-        gbc.gridy++;
-        gbc.weightx = 0;
         yLabel = new JLabel("Y:");
-        add(yLabel, gbc);
-        gbc.gridy++;
+        positionPanel.add(yLabel);
         ySpinner = new JSpinner(new SpinnerNumberModel(0, -10000, 10000, 1));
+        ySpinner.setPreferredSize(new Dimension(60, ySpinner.getPreferredSize().height));
         ySpinner.setEnabled(false);
         ySpinner.addChangeListener(new ChangeListener() {
             @Override
@@ -92,8 +104,21 @@ public class NodePropertiesPanel extends JPanel {
                 }
             }
         });
-        gbc.weightx = 1.0;
-        add(ySpinner, gbc);
+        ((JFormattedTextField) ((JSpinner.DefaultEditor) ySpinner.getEditor()).getTextField()).getDocument().addDocumentListener(new DocumentListener() {
+            public void insertUpdate(DocumentEvent e) { commit(); }
+            public void removeUpdate(DocumentEvent e) { commit(); }
+            public void changedUpdate(DocumentEvent e) { commit(); }
+            private void commit() {
+                try {
+                    ySpinner.commitEdit();
+                } catch (ParseException ex) {
+                    return;
+                }
+            }
+        });
+        positionPanel.add(ySpinner);
+
+        add(positionPanel, gbc);
 
         // Color
         gbc.gridy++;
@@ -158,10 +183,7 @@ public class NodePropertiesPanel extends JPanel {
         boolean visible = node != null;
         labelLabel.setVisible(visible);
         labelField.setVisible(visible);
-        xLabel.setVisible(visible);
-        xSpinner.setVisible(visible);
-        yLabel.setVisible(visible);
-        ySpinner.setVisible(visible);
+        positionPanel.setVisible(visible);
         colorLabel.setVisible(visible);
         colorButton.setVisible(visible);
         metadataLabel.setVisible(visible);

--- a/src/me/wphillips/fsmedit/NodePropertiesPanel.java
+++ b/src/me/wphillips/fsmedit/NodePropertiesPanel.java
@@ -123,7 +123,8 @@ public class NodePropertiesPanel extends JPanel {
         metadataLabel = new JLabel("Metadata:");
         add(metadataLabel, gbc);
         gbc.gridy++;
-        metadataArea = new JTextArea(5, 10);
+        // Slightly taller area for notes
+        metadataArea = new JTextArea(8, 10);
         metadataArea.setLineWrap(true);
         metadataArea.setWrapStyleWord(true);
         metadataArea.setEnabled(false);
@@ -185,5 +186,16 @@ public class NodePropertiesPanel extends JPanel {
         }
         revalidate();
         repaint();
+    }
+
+    /**
+     * Refresh the X and Y spinner values from the current node state. This
+     * is used by the graph panel when a node is dragged.
+     */
+    public void updatePositionFields() {
+        if (node != null) {
+            xSpinner.setValue(node.getX());
+            ySpinner.setValue(node.getY());
+        }
     }
 }

--- a/src/me/wphillips/fsmedit/NodePropertiesPanel.java
+++ b/src/me/wphillips/fsmedit/NodePropertiesPanel.java
@@ -8,7 +8,6 @@ import javax.swing.event.ChangeListener;
 import javax.swing.border.CompoundBorder;
 import javax.swing.border.EmptyBorder;
 import java.awt.*;
-import java.text.ParseException;
 
 public class NodePropertiesPanel extends JPanel {
     private final JLabel labelLabel;
@@ -76,18 +75,7 @@ public class NodePropertiesPanel extends JPanel {
                 }
             }
         });
-        ((JFormattedTextField) ((JSpinner.DefaultEditor) xSpinner.getEditor()).getTextField()).getDocument().addDocumentListener(new DocumentListener() {
-            public void insertUpdate(DocumentEvent e) { commit(); }
-            public void removeUpdate(DocumentEvent e) { commit(); }
-            public void changedUpdate(DocumentEvent e) { commit(); }
-            private void commit() {
-                try {
-                    xSpinner.commitEdit();
-                } catch (ParseException ex) {
-                    return;
-                }
-            }
-        });
+        // Use standard spinner behavior without committing on every keystroke
         positionPanel.add(xSpinner);
 
         yLabel = new JLabel("Y:");
@@ -104,18 +92,7 @@ public class NodePropertiesPanel extends JPanel {
                 }
             }
         });
-        ((JFormattedTextField) ((JSpinner.DefaultEditor) ySpinner.getEditor()).getTextField()).getDocument().addDocumentListener(new DocumentListener() {
-            public void insertUpdate(DocumentEvent e) { commit(); }
-            public void removeUpdate(DocumentEvent e) { commit(); }
-            public void changedUpdate(DocumentEvent e) { commit(); }
-            private void commit() {
-                try {
-                    ySpinner.commitEdit();
-                } catch (ParseException ex) {
-                    return;
-                }
-            }
-        });
+        // Use standard spinner behavior without committing on every keystroke
         positionPanel.add(ySpinner);
 
         add(positionPanel, gbc);


### PR DESCRIPTION
## Summary
- allow editing node x/y position via spinners
- add metadata text area to node properties panel
- store metadata in `Node`

## Testing
- `javac` compilation of all sources

------
https://chatgpt.com/codex/tasks/task_e_68543a2a9784832483b1e97043cb91b0