### PR TITLE
Add persistent color chooser

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,5 @@ The "File" menu provides options to create a new graph, open an existing one and
 The node properties panel includes a **Lock Position** checkbox. When checked,
 the selected node cannot be dragged or repositioned via its X and Y fields.
 When multiple nodes are selected, the panel simply displays "Multiple Items Selected".
+The color picker remembers previously chosen swatches so you can quickly reuse
+recent colors when editing multiple nodes.

--- a/src/me/wphillips/fsmedit/PropertiesPanel.java
+++ b/src/me/wphillips/fsmedit/PropertiesPanel.java
@@ -26,6 +26,10 @@ public class PropertiesPanel extends JPanel {
     private final JCheckBox lockPositionCheck;
     private final JLabel colorLabel;
     private final JButton colorButton;
+    /** Reusable chooser to preserve custom swatches between uses. */
+    private final JColorChooser colorChooser;
+    /** Dialog wrapping {@link #colorChooser}. Recreated only once. */
+    private JDialog colorDialog;
     private final JLabel metadataLabel;
     private final JTextArea metadataArea;
     private final JScrollPane metadataScroll;
@@ -170,15 +174,23 @@ public class PropertiesPanel extends JPanel {
         gbc.gridy++;
         colorButton = new JButton("Select Color");
         colorButton.setEnabled(false);
+        colorChooser = new JColorChooser();
+        colorDialog = null;
         colorButton.addActionListener(e -> {
             if (node != null) {
-                Color newColor = JColorChooser.showDialog(PropertiesPanel.this,
-                        "Choose Node Color", node.getColor());
-                if (newColor != null) {
-                    node.setColor(newColor);
-                    colorButton.setBackground(newColor);
-                    graphPanel.repaint();
+                if (colorDialog == null) {
+                    colorDialog = JColorChooser.createDialog(PropertiesPanel.this,
+                            "Choose Node Color", true, colorChooser, event -> {
+                                if (node != null) {
+                                    Color chosen = colorChooser.getColor();
+                                    node.setColor(chosen);
+                                    colorButton.setBackground(chosen);
+                                    graphPanel.repaint();
+                                }
+                            }, null);
                 }
+                colorChooser.setColor(node.getColor());
+                colorDialog.setVisible(true);
             }
         });
         gbc.weightx = 1.0;


### PR DESCRIPTION
## Summary
- preserve custom swatches by reusing a single `JColorChooser`
- document color picker behavior in README

## Testing
- `javac $(find src -name '*.java')`

------
https://chatgpt.com/codex/tasks/task_e_6860172b698883249eb363b6ca0e661e