### PR TITLE
Add edge text labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,4 +29,5 @@ recent colors when editing multiple nodes.
 
 When an edge is selected the properties panel lets you change its spline type,
 curvature and an optional text string. The text is drawn near the middle of the
-edge in the graph view.
+edge in the graph view and is rendered over a white background so it remains
+readable regardless of the edge color.

--- a/README.md
+++ b/README.md
@@ -30,4 +30,5 @@ recent colors when editing multiple nodes.
 When an edge is selected the properties panel lets you change its spline type,
 curvature and an optional text string. The text is drawn near the middle of the
 edge in the graph view and is rendered over a white background so it remains
-readable regardless of the edge color.
+readable regardless of the edge color. Long labels will automatically wrap to
+multiple lines when they exceed about 120 pixels in width.

--- a/README.md
+++ b/README.md
@@ -24,3 +24,9 @@ the selected node cannot be dragged or repositioned via its X and Y fields.
 When multiple nodes are selected, the panel shows how many nodes are selected, e.g., "10 Nodes Selected".
 The color picker remembers previously chosen swatches so you can quickly reuse
 recent colors when editing multiple nodes.
+
+## Edge Properties
+
+When an edge is selected the properties panel lets you change its spline type,
+curvature and an optional text string. The text is drawn near the middle of the
+edge in the graph view.

--- a/src/me/wphillips/fsmedit/Edge.java
+++ b/src/me/wphillips/fsmedit/Edge.java
@@ -14,6 +14,8 @@ public class Edge implements Serializable {
     private SplineType splineType;
     /** Controls the curvature when using a bezier spline. */
     private float curvature;
+    /** Optional text displayed near this edge. */
+    private String text;
 
     public Edge(Node from, Node to) {
         this(from, to, SplineType.STRAIGHT);
@@ -24,6 +26,7 @@ public class Edge implements Serializable {
         this.to = to;
         this.splineType = type;
         this.curvature = 0.4f;
+        this.text = "";
     }
 
     public Node getFrom() {
@@ -54,6 +57,16 @@ public class Edge implements Serializable {
         this.curvature = curvature;
     }
 
+    /** Get the optional text displayed near this edge. */
+    public String getText() {
+        return text == null ? "" : text;
+    }
+
+    /** Set the text to display near this edge. */
+    public void setText(String text) {
+        this.text = text == null ? "" : text;
+    }
+
     /**
      * Update the destination node for this edge.
      */
@@ -69,6 +82,9 @@ public class Edge implements Serializable {
         }
         if (curvature == 0f) {
             curvature = 0.4f;
+        }
+        if (text == null) {
+            text = "";
         }
     }
 }

--- a/src/me/wphillips/fsmedit/GraphPanel.java
+++ b/src/me/wphillips/fsmedit/GraphPanel.java
@@ -699,9 +699,21 @@ public class GraphPanel extends JPanel {
             pos = new Point((p1.x + p2.x) / 2, (p1.y + p2.y) / 2);
         }
         FontMetrics fm = g2.getFontMetrics();
-        int w = fm.stringWidth(text);
-        int h = fm.getAscent();
-        g2.drawString(text, pos.x - w / 2, pos.y - 4 - h / 2);
+        int ascent = fm.getAscent();
+        int descent = fm.getDescent();
+        int textWidth = fm.stringWidth(text);
+        int centerY = pos.y - 4;
+        int baseline = centerY + (ascent - descent) / 2;
+        int x = pos.x - textWidth / 2;
+        int y = baseline - ascent;
+
+        Color prev = g2.getColor();
+        g2.setColor(Color.WHITE);
+        g2.fillRect(x - 2, y - 2, textWidth + 4, ascent + descent + 4);
+        g2.setColor(Color.BLACK);
+        g2.drawRect(x - 2, y - 2, textWidth + 4, ascent + descent + 4);
+        g2.drawString(text, x, baseline);
+        g2.setColor(prev);
     }
 
     /**

--- a/src/me/wphillips/fsmedit/GraphPanel.java
+++ b/src/me/wphillips/fsmedit/GraphPanel.java
@@ -744,25 +744,25 @@ public class GraphPanel extends JPanel {
         String[] words = text.split("\\s+");
         StringBuilder line = new StringBuilder();
         for (String word : words) {
-            String candidate = line.length() == 0 ? word : line + " " + word;
-            if (fm.stringWidth(candidate) <= maxWidth) {
-                line.setLength(0);
-                line.append(candidate);
-            } else {
-                if (line.length() > 0) {
-                    lines.add(line.toString());
-                    line.setLength(0);
+            if (line.length() == 0) {
+                if (fm.stringWidth(word) <= maxWidth) {
+                    line.append(word);
+                } else {
+                    splitWord(lines, fm, word, maxWidth);
                 }
-                // If the word itself is longer than maxWidth break it mid-word
-                int start = 0;
-                while (start < word.length()) {
-                    int end = start + 1;
-                    while (end <= word.length() && fm.stringWidth(word.substring(start, end)) <= maxWidth) {
-                        end++;
-                    }
-                    end--;
-                    lines.add(word.substring(start, end));
-                    start = end;
+                continue;
+            }
+
+            String candidate = line + " " + word;
+            if (fm.stringWidth(candidate) <= maxWidth) {
+                line.append(' ').append(word);
+            } else {
+                lines.add(line.toString());
+                line.setLength(0);
+                if (fm.stringWidth(word) <= maxWidth) {
+                    line.append(word);
+                } else {
+                    splitWord(lines, fm, word, maxWidth);
                 }
             }
         }
@@ -770,6 +770,20 @@ public class GraphPanel extends JPanel {
             lines.add(line.toString());
         }
         return lines;
+    }
+
+    /** Break a long word into multiple lines. */
+    private static void splitWord(java.util.List<String> lines, FontMetrics fm, String word, int maxWidth) {
+        int start = 0;
+        while (start < word.length()) {
+            int end = start + 1;
+            while (end <= word.length() && fm.stringWidth(word.substring(start, end)) <= maxWidth) {
+                end++;
+            }
+            end--;
+            lines.add(word.substring(start, end));
+            start = end;
+        }
     }
 
     /**

--- a/src/me/wphillips/fsmedit/GraphPanel.java
+++ b/src/me/wphillips/fsmedit/GraphPanel.java
@@ -524,6 +524,7 @@ public class GraphPanel extends JPanel {
                     g2.setStroke(new BasicStroke(2f));
                 }
                 drawArrow(g2, e);
+                drawEdgeText(g2, e);
                 if (e == selectedEdge) {
                     g2.setStroke(old);
                     g2.setColor(Color.BLACK);
@@ -678,6 +679,31 @@ public class GraphPanel extends JPanel {
         }
     }
 
+    /** Draw any text associated with the given edge near its midpoint. */
+    private void drawEdgeText(Graphics2D g2, Edge edge) {
+        String text = edge.getText();
+        if (text == null || text.isEmpty()) {
+            return;
+        }
+        Point pos;
+        if (edge.getSplineType() == Edge.SplineType.BEZIER) {
+            Point cp = bezierControlPoint(edge.getFrom(), edge.getTo(), edge.getCurvature());
+            Point p1 = boundaryPoint(edge.getFrom(), cp.x, cp.y);
+            Point p2 = boundaryPoint(edge.getTo(), cp.x, cp.y);
+            double mx = 0.25 * p1.x + 0.5 * cp.x + 0.25 * p2.x;
+            double my = 0.25 * p1.y + 0.5 * cp.y + 0.25 * p2.y;
+            pos = new Point((int) Math.round(mx), (int) Math.round(my));
+        } else {
+            Point p1 = boundaryPoint(edge.getFrom(), edge.getTo());
+            Point p2 = boundaryPoint(edge.getTo(), edge.getFrom());
+            pos = new Point((p1.x + p2.x) / 2, (p1.y + p2.y) / 2);
+        }
+        FontMetrics fm = g2.getFontMetrics();
+        int w = fm.stringWidth(text);
+        int h = fm.getAscent();
+        g2.drawString(text, pos.x - w / 2, pos.y - 4 - h / 2);
+    }
+
     /**
      * Get a snapshot of the currently selected nodes.
      */
@@ -732,6 +758,7 @@ public class GraphPanel extends JPanel {
             if (map.containsKey(e.getFrom()) && map.containsKey(e.getTo())) {
                 Edge ec = new Edge(map.get(e.getFrom()), map.get(e.getTo()), e.getSplineType());
                 ec.setCurvature(e.getCurvature());
+                ec.setText(e.getText());
                 clipboardEdges.add(ec);
             }
         }
@@ -776,6 +803,7 @@ public class GraphPanel extends JPanel {
             if (from != null && to != null) {
                 Edge ec = new Edge(from, to, e.getSplineType());
                 ec.setCurvature(e.getCurvature());
+                ec.setText(e.getText());
                 edges.add(ec);
             }
         }

--- a/src/me/wphillips/fsmedit/PropertiesPanel.java
+++ b/src/me/wphillips/fsmedit/PropertiesPanel.java
@@ -23,6 +23,8 @@ public class PropertiesPanel extends JPanel {
     private final JComboBox<Edge.SplineType> splineCombo;
     private final JLabel curvatureLabel;
     private final JSpinner curvatureSpinner;
+    private final JLabel edgeTextLabel;
+    private final JTextField edgeTextField;
     private final JCheckBox lockPositionCheck;
     private final JLabel colorLabel;
     private final JButton colorButton;
@@ -153,6 +155,26 @@ public class PropertiesPanel extends JPanel {
         });
         add(curvatureSpinner, gbc);
 
+        // Edge text
+        gbc.gridy++;
+        edgeTextLabel = new JLabel("Text:");
+        add(edgeTextLabel, gbc);
+        gbc.gridy++;
+        edgeTextField = new JTextField();
+        edgeTextField.setEnabled(false);
+        edgeTextField.getDocument().addDocumentListener(new DocumentListener() {
+            public void insertUpdate(DocumentEvent e) { update(); }
+            public void removeUpdate(DocumentEvent e) { update(); }
+            public void changedUpdate(DocumentEvent e) { update(); }
+            private void update() {
+                if (edge != null) {
+                    edge.setText(edgeTextField.getText());
+                    graphPanel.repaint();
+                }
+            }
+        });
+        add(edgeTextField, gbc);
+
         // Lock checkbox just below the position controls
         gbc.gridy++;
         lockPositionCheck = new JCheckBox("Lock Position");
@@ -248,6 +270,8 @@ public class PropertiesPanel extends JPanel {
         splineCombo.setVisible(false);
         curvatureLabel.setVisible(false);
         curvatureSpinner.setVisible(false);
+        edgeTextLabel.setVisible(false);
+        edgeTextField.setVisible(false);
         colorLabel.setVisible(visible);
         colorButton.setVisible(visible);
         metadataLabel.setVisible(visible);
@@ -257,6 +281,7 @@ public class PropertiesPanel extends JPanel {
         labelField.setEnabled(visible);
         colorButton.setEnabled(visible);
         metadataArea.setEnabled(visible);
+        edgeTextField.setEnabled(false);
         if (visible) {
             xSpinner.setEnabled(!node.isLocked());
             ySpinner.setEnabled(!node.isLocked());
@@ -306,14 +331,19 @@ public class PropertiesPanel extends JPanel {
         splineCombo.setVisible(visible);
         curvatureLabel.setVisible(visible);
         curvatureSpinner.setVisible(visible);
+        edgeTextLabel.setVisible(visible);
+        edgeTextField.setVisible(visible);
         splineCombo.setEnabled(visible);
         curvatureSpinner.setEnabled(visible);
+        edgeTextField.setEnabled(visible);
         if (edge == null) {
             splineCombo.setSelectedIndex(0);
             curvatureSpinner.setValue(0.4);
+            edgeTextField.setText("");
         } else {
             splineCombo.setSelectedItem(edge.getSplineType());
             curvatureSpinner.setValue((double) edge.getCurvature());
+            edgeTextField.setText(edge.getText());
         }
         revalidate();
         repaint();
@@ -335,6 +365,8 @@ public class PropertiesPanel extends JPanel {
             splineCombo.setVisible(false);
             curvatureLabel.setVisible(false);
             curvatureSpinner.setVisible(false);
+            edgeTextLabel.setVisible(false);
+            edgeTextField.setVisible(false);
             colorLabel.setVisible(false);
             colorButton.setVisible(false);
             metadataLabel.setVisible(false);
@@ -367,6 +399,8 @@ public class PropertiesPanel extends JPanel {
         splineCombo.setVisible(false);
         curvatureLabel.setVisible(false);
         curvatureSpinner.setVisible(false);
+        edgeTextLabel.setVisible(false);
+        edgeTextField.setVisible(false);
         colorLabel.setVisible(false);
         colorButton.setVisible(false);
         metadataLabel.setVisible(false);


### PR DESCRIPTION
## Summary
- support optional text for edges
- draw labels near edges
- expose edge text field in properties panel
- document edge properties in README

## Testing
- `javac $(find src -name '*.java')`

------
https://chatgpt.com/codex/tasks/task_e_68609f0e77a48324966dbd6e17841123