### PR TITLE
Add cycle analysis tool with loop highlighting

### DIFF
--- a/src/me/wphillips/fsmedit/CycleAnalysisDialog.java
+++ b/src/me/wphillips/fsmedit/CycleAnalysisDialog.java
@@ -24,9 +24,9 @@ public class CycleAnalysisDialog extends JDialog {
     private final JButton prevButton;
     private final JButton nextButton;
     private final JButton analyzeButton;
-    private final JButton copyButton;
     private final JButton clearButton;
     private final JTextArea loopDetailsArea;
+    private final JMenuItem copyMenuItem;
     private boolean hasRunAnalysis;
     private final GraphPanel.NodeSelectionListener nodeSelectionListener;
 
@@ -59,11 +59,16 @@ public class CycleAnalysisDialog extends JDialog {
         if (inactive != null) {
             loopDetailsArea.setBackground(inactive);
         }
-        loopDetailsArea.setBorder(BorderFactory.createLineBorder(Color.LIGHT_GRAY));
+        loopDetailsArea.setBorder(BorderFactory.createCompoundBorder(
+                BorderFactory.createLineBorder(Color.LIGHT_GRAY),
+                BorderFactory.createEmptyBorder(6, 6, 6, 6)));
 
-        copyButton = new JButton("Copy");
-        copyButton.addActionListener(e -> copyLoopDetails());
-        copyButton.setEnabled(false);
+        JPopupMenu loopPopupMenu = new JPopupMenu();
+        copyMenuItem = new JMenuItem("Copy");
+        copyMenuItem.addActionListener(e -> copyLoopDetails());
+        copyMenuItem.setEnabled(false);
+        loopPopupMenu.add(copyMenuItem);
+        loopDetailsArea.setComponentPopupMenu(loopPopupMenu);
 
         clearButton = new JButton("Clear");
         clearButton.addActionListener(e -> clearAnalysis());
@@ -90,7 +95,6 @@ public class CycleAnalysisDialog extends JDialog {
         loopPanel.add(loopScroll, BorderLayout.CENTER);
 
         JPanel actionPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
-        actionPanel.add(copyButton);
         actionPanel.add(clearButton);
         actionPanel.add(closeButton);
 
@@ -213,7 +217,7 @@ public class CycleAnalysisDialog extends JDialog {
             clearButton.setEnabled(hasRunAnalysis);
             statusLabel.setText("Add nodes to analyze cycles.");
             loopDetailsArea.setText("");
-            updateCopyButtonState();
+            updateCopyMenuState();
             return;
         }
 
@@ -223,7 +227,7 @@ public class CycleAnalysisDialog extends JDialog {
             clearButton.setEnabled(hasRunAnalysis);
             statusLabel.setText("Click a node in the graph to choose a start point.");
             loopDetailsArea.setText("");
-            updateCopyButtonState();
+            updateCopyMenuState();
             return;
         }
 
@@ -247,7 +251,7 @@ public class CycleAnalysisDialog extends JDialog {
             loopDetailsArea.setText("");
         }
         loopDetailsArea.setCaretPosition(0);
-        updateCopyButtonState();
+        updateCopyMenuState();
     }
 
     private void copyLoopDetails() {
@@ -259,9 +263,9 @@ public class CycleAnalysisDialog extends JDialog {
         clipboard.setContents(new StringSelection(text), null);
     }
 
-    private void updateCopyButtonState() {
+    private void updateCopyMenuState() {
         String text = loopDetailsArea.getText();
-        copyButton.setEnabled(text != null && !text.isEmpty());
+        copyMenuItem.setEnabled(text != null && !text.isEmpty());
     }
 
     private String describeCycle(List<Edge> cycle) {

--- a/src/me/wphillips/fsmedit/CycleAnalysisDialog.java
+++ b/src/me/wphillips/fsmedit/CycleAnalysisDialog.java
@@ -4,6 +4,10 @@ import javax.swing.*;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.FlowLayout;
+import java.awt.Insets;
+import java.awt.Toolkit;
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.StringSelection;
 import java.awt.Window;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
@@ -20,6 +24,7 @@ public class CycleAnalysisDialog extends JDialog {
     private final JButton prevButton;
     private final JButton nextButton;
     private final JButton analyzeButton;
+    private final JButton copyButton;
     private final JButton clearButton;
     private final JTextArea loopDetailsArea;
     private boolean hasRunAnalysis;
@@ -49,11 +54,16 @@ public class CycleAnalysisDialog extends JDialog {
         loopDetailsArea.setWrapStyleWord(true);
         loopDetailsArea.setEditable(false);
         loopDetailsArea.setFocusable(false);
+        loopDetailsArea.setMargin(new Insets(6, 6, 6, 6));
         Color inactive = UIManager.getColor("TextArea.inactiveBackground");
         if (inactive != null) {
             loopDetailsArea.setBackground(inactive);
         }
         loopDetailsArea.setBorder(BorderFactory.createLineBorder(Color.LIGHT_GRAY));
+
+        copyButton = new JButton("Copy");
+        copyButton.addActionListener(e -> copyLoopDetails());
+        copyButton.setEnabled(false);
 
         clearButton = new JButton("Clear");
         clearButton.addActionListener(e -> clearAnalysis());
@@ -80,6 +90,7 @@ public class CycleAnalysisDialog extends JDialog {
         loopPanel.add(loopScroll, BorderLayout.CENTER);
 
         JPanel actionPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+        actionPanel.add(copyButton);
         actionPanel.add(clearButton);
         actionPanel.add(closeButton);
 
@@ -202,6 +213,7 @@ public class CycleAnalysisDialog extends JDialog {
             clearButton.setEnabled(hasRunAnalysis);
             statusLabel.setText("Add nodes to analyze cycles.");
             loopDetailsArea.setText("");
+            updateCopyButtonState();
             return;
         }
 
@@ -211,6 +223,7 @@ public class CycleAnalysisDialog extends JDialog {
             clearButton.setEnabled(hasRunAnalysis);
             statusLabel.setText("Click a node in the graph to choose a start point.");
             loopDetailsArea.setText("");
+            updateCopyButtonState();
             return;
         }
 
@@ -234,6 +247,21 @@ public class CycleAnalysisDialog extends JDialog {
             loopDetailsArea.setText("");
         }
         loopDetailsArea.setCaretPosition(0);
+        updateCopyButtonState();
+    }
+
+    private void copyLoopDetails() {
+        String text = loopDetailsArea.getText();
+        if (text == null || text.isEmpty()) {
+            return;
+        }
+        Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+        clipboard.setContents(new StringSelection(text), null);
+    }
+
+    private void updateCopyButtonState() {
+        String text = loopDetailsArea.getText();
+        copyButton.setEnabled(text != null && !text.isEmpty());
     }
 
     private String describeCycle(List<Edge> cycle) {

--- a/src/me/wphillips/fsmedit/CycleAnalysisDialog.java
+++ b/src/me/wphillips/fsmedit/CycleAnalysisDialog.java
@@ -2,9 +2,11 @@ package me.wphillips.fsmedit;
 
 import javax.swing.*;
 import java.awt.BorderLayout;
-import java.awt.Component;
+import java.awt.Color;
 import java.awt.FlowLayout;
 import java.awt.Window;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.util.List;
 
 /**
@@ -12,41 +14,25 @@ import java.util.List;
  */
 public class CycleAnalysisDialog extends JDialog {
     private final GraphPanel panel;
-    private final JComboBox<Node> nodeSelector;
+    private Node selectedStartNode;
+    private final JLabel startNodeLabel;
     private final JLabel statusLabel;
     private final JButton prevButton;
     private final JButton nextButton;
     private final JButton analyzeButton;
     private final JButton clearButton;
+    private final JTextArea loopDetailsArea;
     private boolean hasRunAnalysis;
+    private final GraphPanel.NodeSelectionListener nodeSelectionListener;
 
     public CycleAnalysisDialog(Window owner, GraphPanel panel) {
         super(owner, "Cycle Analysis", ModalityType.MODELESS);
         this.panel = panel;
         setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
 
-        DefaultComboBoxModel<Node> nodeModel = new DefaultComboBoxModel<>();
-        nodeSelector = new JComboBox<>(nodeModel);
-        nodeSelector.setRenderer(new DefaultListCellRenderer() {
-            @Override
-            public Component getListCellRendererComponent(JList<?> list, Object value,
-                    int index, boolean isSelected, boolean cellHasFocus) {
-                Component comp = super.getListCellRendererComponent(list, value, index,
-                        isSelected, cellHasFocus);
-                if (value instanceof Node) {
-                    Node node = (Node) value;
-                    String label = node.getLabel();
-                    if (label == null || label.isEmpty()) {
-                        label = "(unnamed)";
-                    }
-                    setText(label);
-                }
-                return comp;
-            }
-        });
-
         analyzeButton = new JButton("Analyze");
         analyzeButton.addActionListener(e -> runAnalysis());
+        analyzeButton.setEnabled(false);
 
         prevButton = new JButton("\u2190");
         prevButton.addActionListener(e -> showPreviousCycle());
@@ -54,17 +40,30 @@ public class CycleAnalysisDialog extends JDialog {
         nextButton = new JButton("\u2192");
         nextButton.addActionListener(e -> showNextCycle());
 
-        statusLabel = new JLabel("Select a node and click Analyze to search for loops.");
+        statusLabel = new JLabel("Click a node in the graph to choose a start point.");
+
+        startNodeLabel = new JLabel("(click a node in the graph)");
+
+        loopDetailsArea = new JTextArea(3, 30);
+        loopDetailsArea.setLineWrap(true);
+        loopDetailsArea.setWrapStyleWord(true);
+        loopDetailsArea.setEditable(false);
+        loopDetailsArea.setFocusable(false);
+        Color inactive = UIManager.getColor("TextArea.inactiveBackground");
+        if (inactive != null) {
+            loopDetailsArea.setBackground(inactive);
+        }
+        loopDetailsArea.setBorder(BorderFactory.createLineBorder(Color.LIGHT_GRAY));
 
         clearButton = new JButton("Clear");
         clearButton.addActionListener(e -> clearAnalysis());
 
         JButton closeButton = new JButton("Close");
-        closeButton.addActionListener(e -> setVisible(false));
+        closeButton.addActionListener(e -> dispose());
 
         JPanel selectPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
         selectPanel.add(new JLabel("Start node:"));
-        selectPanel.add(nodeSelector);
+        selectPanel.add(startNodeLabel);
         selectPanel.add(analyzeButton);
 
         JPanel navigationPanel = new JPanel(new FlowLayout(FlowLayout.CENTER));
@@ -72,42 +71,82 @@ public class CycleAnalysisDialog extends JDialog {
         navigationPanel.add(statusLabel);
         navigationPanel.add(nextButton);
 
+        JPanel loopPanel = new JPanel(new BorderLayout());
+        loopPanel.setBorder(BorderFactory.createTitledBorder("Loop Path"));
+        JScrollPane loopScroll = new JScrollPane(loopDetailsArea,
+                ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED,
+                ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
+        loopScroll.setBorder(BorderFactory.createEmptyBorder());
+        loopPanel.add(loopScroll, BorderLayout.CENTER);
+
         JPanel actionPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
         actionPanel.add(clearButton);
         actionPanel.add(closeButton);
 
         setLayout(new BorderLayout(10, 10));
         add(selectPanel, BorderLayout.NORTH);
-        add(navigationPanel, BorderLayout.CENTER);
+        JPanel centerPanel = new JPanel(new BorderLayout(5, 5));
+        centerPanel.add(loopPanel, BorderLayout.CENTER);
+        centerPanel.add(navigationPanel, BorderLayout.SOUTH);
+        add(centerPanel, BorderLayout.CENTER);
         add(actionPanel, BorderLayout.SOUTH);
+
+        List<Node> selected = panel.getSelectedNodes();
+        if (!selected.isEmpty()) {
+            selectedStartNode = selected.get(0);
+        }
+        updateStartNodeLabel(selectedStartNode);
+        updateNavigation();
+
+        nodeSelectionListener = this::handleNodeSelection;
+        panel.addNodeSelectionListener(nodeSelectionListener);
+        addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowClosed(WindowEvent e) {
+                panel.removeNodeSelectionListener(nodeSelectionListener);
+            }
+
+            @Override
+            public void windowClosing(WindowEvent e) {
+                panel.removeNodeSelectionListener(nodeSelectionListener);
+            }
+        });
 
         pack();
         setLocationRelativeTo(owner);
         setResizable(false);
+    }
 
-        refreshNodeList();
+    private void handleNodeSelection(Node node) {
+        if (node == null) {
+            return;
+        }
+        if (node != selectedStartNode) {
+            selectedStartNode = node;
+            hasRunAnalysis = false;
+            panel.clearCycleAnalysis();
+        }
+        updateStartNodeLabel(selectedStartNode);
         updateNavigation();
     }
 
-    private void refreshNodeList() {
-        DefaultComboBoxModel<Node> model = (DefaultComboBoxModel<Node>) nodeSelector.getModel();
-        model.removeAllElements();
-        for (Node node : panel.getNodes()) {
-            model.addElement(node);
+    private void updateStartNodeLabel(Node node) {
+        if (node == null) {
+            startNodeLabel.setText("(click a node in the graph)");
+        } else {
+            startNodeLabel.setText(formatNodeLabel(node));
         }
-        boolean hasNodes = model.getSize() > 0;
-        analyzeButton.setEnabled(hasNodes);
     }
 
     private void runAnalysis() {
-        Node selected = (Node) nodeSelector.getSelectedItem();
-        if (selected == null) {
-            JOptionPane.showMessageDialog(this, "Select a node to analyze.",
+        if (selectedStartNode == null) {
+            JOptionPane.showMessageDialog(this,
+                    "Click a node in the graph to choose a start point.",
                     "No Node Selected", JOptionPane.WARNING_MESSAGE);
             return;
         }
         hasRunAnalysis = true;
-        List<List<Edge>> results = panel.findCyclesFrom(selected);
+        List<List<Edge>> results = panel.findCyclesFrom(selectedStartNode);
         if (results.isEmpty()) {
             panel.clearCycleAnalysis();
         } else {
@@ -149,14 +188,29 @@ public class CycleAnalysisDialog extends JDialog {
     }
 
     private void updateNavigation() {
-        DefaultComboBoxModel<Node> model = (DefaultComboBoxModel<Node>) nodeSelector.getModel();
-        boolean hasNodes = model.getSize() > 0;
-        analyzeButton.setEnabled(hasNodes);
+        if (selectedStartNode != null && !panel.getNodes().contains(selectedStartNode)) {
+            selectedStartNode = null;
+            updateStartNodeLabel(null);
+        }
+
+        boolean hasNodes = panel.getNodeCount() > 0;
+        boolean hasStartNode = selectedStartNode != null;
+        analyzeButton.setEnabled(hasNodes && hasStartNode);
         if (!hasNodes) {
             prevButton.setEnabled(false);
             nextButton.setEnabled(false);
             clearButton.setEnabled(hasRunAnalysis);
             statusLabel.setText("Add nodes to analyze cycles.");
+            loopDetailsArea.setText("");
+            return;
+        }
+
+        if (!hasStartNode) {
+            prevButton.setEnabled(false);
+            nextButton.setEnabled(false);
+            clearButton.setEnabled(hasRunAnalysis);
+            statusLabel.setText("Click a node in the graph to choose a start point.");
+            loopDetailsArea.setText("");
             return;
         }
 
@@ -167,14 +221,43 @@ public class CycleAnalysisDialog extends JDialog {
         clearButton.setEnabled(hasCycles || hasRunAnalysis);
         if (hasCycles) {
             int index = panel.getCurrentCycleIndex();
-            if (index < 0) {
+            if (index < 0 || index >= count) {
                 index = 0;
             }
             statusLabel.setText(String.format("Loop %d of %d", index + 1, count));
+            loopDetailsArea.setText(describeCycle(panel.getCycleAnalysisLoops().get(index)));
         } else if (hasRunAnalysis) {
             statusLabel.setText("No loops found.");
+            loopDetailsArea.setText("");
         } else {
-            statusLabel.setText("Select a node and click Analyze to search for loops.");
+            statusLabel.setText("Click Analyze to search for loops.");
+            loopDetailsArea.setText("");
         }
+        loopDetailsArea.setCaretPosition(0);
+    }
+
+    private String describeCycle(List<Edge> cycle) {
+        if (cycle == null || cycle.isEmpty()) {
+            return "";
+        }
+        StringBuilder builder = new StringBuilder();
+        Node start = cycle.get(0).getFrom();
+        builder.append(formatNodeLabel(start));
+        for (Edge edge : cycle) {
+            builder.append(" -> ");
+            builder.append(formatNodeLabel(edge.getTo()));
+        }
+        return builder.toString();
+    }
+
+    private String formatNodeLabel(Node node) {
+        if (node == null) {
+            return "";
+        }
+        String label = node.getLabel();
+        if (label == null || label.isEmpty()) {
+            label = "(unnamed)";
+        }
+        return label;
     }
 }

--- a/src/me/wphillips/fsmedit/CycleAnalysisDialog.java
+++ b/src/me/wphillips/fsmedit/CycleAnalysisDialog.java
@@ -1,0 +1,180 @@
+package me.wphillips.fsmedit;
+
+import javax.swing.*;
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.FlowLayout;
+import java.awt.Window;
+import java.util.List;
+
+/**
+ * Dialog that guides the user through analyzing cycles starting from a chosen node.
+ */
+public class CycleAnalysisDialog extends JDialog {
+    private final GraphPanel panel;
+    private final JComboBox<Node> nodeSelector;
+    private final JLabel statusLabel;
+    private final JButton prevButton;
+    private final JButton nextButton;
+    private final JButton analyzeButton;
+    private final JButton clearButton;
+    private boolean hasRunAnalysis;
+
+    public CycleAnalysisDialog(Window owner, GraphPanel panel) {
+        super(owner, "Cycle Analysis", ModalityType.MODELESS);
+        this.panel = panel;
+        setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+
+        DefaultComboBoxModel<Node> nodeModel = new DefaultComboBoxModel<>();
+        nodeSelector = new JComboBox<>(nodeModel);
+        nodeSelector.setRenderer(new DefaultListCellRenderer() {
+            @Override
+            public Component getListCellRendererComponent(JList<?> list, Object value,
+                    int index, boolean isSelected, boolean cellHasFocus) {
+                Component comp = super.getListCellRendererComponent(list, value, index,
+                        isSelected, cellHasFocus);
+                if (value instanceof Node) {
+                    Node node = (Node) value;
+                    String label = node.getLabel();
+                    if (label == null || label.isEmpty()) {
+                        label = "(unnamed)";
+                    }
+                    setText(label);
+                }
+                return comp;
+            }
+        });
+
+        analyzeButton = new JButton("Analyze");
+        analyzeButton.addActionListener(e -> runAnalysis());
+
+        prevButton = new JButton("\u2190");
+        prevButton.addActionListener(e -> showPreviousCycle());
+
+        nextButton = new JButton("\u2192");
+        nextButton.addActionListener(e -> showNextCycle());
+
+        statusLabel = new JLabel("Select a node and click Analyze to search for loops.");
+
+        clearButton = new JButton("Clear");
+        clearButton.addActionListener(e -> clearAnalysis());
+
+        JButton closeButton = new JButton("Close");
+        closeButton.addActionListener(e -> setVisible(false));
+
+        JPanel selectPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
+        selectPanel.add(new JLabel("Start node:"));
+        selectPanel.add(nodeSelector);
+        selectPanel.add(analyzeButton);
+
+        JPanel navigationPanel = new JPanel(new FlowLayout(FlowLayout.CENTER));
+        navigationPanel.add(prevButton);
+        navigationPanel.add(statusLabel);
+        navigationPanel.add(nextButton);
+
+        JPanel actionPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+        actionPanel.add(clearButton);
+        actionPanel.add(closeButton);
+
+        setLayout(new BorderLayout(10, 10));
+        add(selectPanel, BorderLayout.NORTH);
+        add(navigationPanel, BorderLayout.CENTER);
+        add(actionPanel, BorderLayout.SOUTH);
+
+        pack();
+        setLocationRelativeTo(owner);
+        setResizable(false);
+
+        refreshNodeList();
+        updateNavigation();
+    }
+
+    private void refreshNodeList() {
+        DefaultComboBoxModel<Node> model = (DefaultComboBoxModel<Node>) nodeSelector.getModel();
+        model.removeAllElements();
+        for (Node node : panel.getNodes()) {
+            model.addElement(node);
+        }
+        boolean hasNodes = model.getSize() > 0;
+        analyzeButton.setEnabled(hasNodes);
+    }
+
+    private void runAnalysis() {
+        Node selected = (Node) nodeSelector.getSelectedItem();
+        if (selected == null) {
+            JOptionPane.showMessageDialog(this, "Select a node to analyze.",
+                    "No Node Selected", JOptionPane.WARNING_MESSAGE);
+            return;
+        }
+        hasRunAnalysis = true;
+        List<List<Edge>> results = panel.findCyclesFrom(selected);
+        if (results.isEmpty()) {
+            panel.clearCycleAnalysis();
+        } else {
+            panel.setCycleAnalysis(results);
+        }
+        updateNavigation();
+    }
+
+    private void showPreviousCycle() {
+        int count = panel.getCycleAnalysisCount();
+        if (count == 0) {
+            return;
+        }
+        int index = panel.getCurrentCycleIndex() - 1;
+        if (index < 0) {
+            index = count - 1;
+        }
+        panel.setCurrentCycleIndex(index);
+        updateNavigation();
+    }
+
+    private void showNextCycle() {
+        int count = panel.getCycleAnalysisCount();
+        if (count == 0) {
+            return;
+        }
+        int index = panel.getCurrentCycleIndex() + 1;
+        if (index >= count) {
+            index = 0;
+        }
+        panel.setCurrentCycleIndex(index);
+        updateNavigation();
+    }
+
+    private void clearAnalysis() {
+        panel.clearCycleAnalysis();
+        hasRunAnalysis = false;
+        updateNavigation();
+    }
+
+    private void updateNavigation() {
+        DefaultComboBoxModel<Node> model = (DefaultComboBoxModel<Node>) nodeSelector.getModel();
+        boolean hasNodes = model.getSize() > 0;
+        analyzeButton.setEnabled(hasNodes);
+        if (!hasNodes) {
+            prevButton.setEnabled(false);
+            nextButton.setEnabled(false);
+            clearButton.setEnabled(hasRunAnalysis);
+            statusLabel.setText("Add nodes to analyze cycles.");
+            return;
+        }
+
+        int count = panel.getCycleAnalysisCount();
+        boolean hasCycles = count > 0;
+        prevButton.setEnabled(hasCycles && count > 1);
+        nextButton.setEnabled(hasCycles && count > 1);
+        clearButton.setEnabled(hasCycles || hasRunAnalysis);
+        if (hasCycles) {
+            int index = panel.getCurrentCycleIndex();
+            if (index < 0) {
+                index = 0;
+            }
+            statusLabel.setText(String.format("Loop %d of %d", index + 1, count));
+        } else if (hasRunAnalysis) {
+            statusLabel.setText("No loops found.");
+        } else {
+            statusLabel.setText("Select a node and click Analyze to search for loops.");
+        }
+    }
+}

--- a/src/me/wphillips/fsmedit/GraphMenuBar.java
+++ b/src/me/wphillips/fsmedit/GraphMenuBar.java
@@ -3,6 +3,7 @@ package me.wphillips.fsmedit;
 import javax.swing.*;
 import javax.swing.filechooser.FileNameExtensionFilter;
 import java.awt.Toolkit;
+import java.awt.Window;
 import java.awt.event.KeyEvent;
 import java.awt.event.InputEvent;
 
@@ -117,8 +118,28 @@ public class GraphMenuBar extends JMenuBar {
         snapItem.addActionListener(e -> panel.setSnapToGrid(snapItem.isSelected()));
         viewMenu.add(snapItem);
 
+        JMenu toolsMenu = new JMenu("Tools");
+        JMenuItem cycleAnalysisItem = new JMenuItem("Cycle Analysis...");
+        cycleAnalysisItem.addActionListener(e -> {
+            if (panel.getNodeCount() == 0) {
+                JOptionPane.showMessageDialog(panel,
+                        "Add nodes to analyze cycles.",
+                        "No Nodes", JOptionPane.INFORMATION_MESSAGE);
+                return;
+            }
+            Window owner = SwingUtilities.getWindowAncestor(panel);
+            CycleAnalysisDialog dialog = new CycleAnalysisDialog(owner, panel);
+            dialog.setVisible(true);
+        });
+        toolsMenu.add(cycleAnalysisItem);
+
+        JMenuItem clearAnalysisItem = new JMenuItem("Clear Analysis");
+        clearAnalysisItem.addActionListener(e -> panel.clearCycleAnalysis());
+        toolsMenu.add(clearAnalysisItem);
+
         add(fileMenu);
         add(editMenu);
         add(viewMenu);
+        add(toolsMenu);
     }
 }

--- a/src/me/wphillips/fsmedit/GraphPanel.java
+++ b/src/me/wphillips/fsmedit/GraphPanel.java
@@ -46,6 +46,9 @@ public class GraphPanel extends JPanel {
     private int clipboardCenterX;
     private int clipboardCenterY;
 
+    /** Listeners notified when the user selects a node. */
+    private final List<NodeSelectionListener> nodeSelectionListeners = new ArrayList<>();
+
     /** Detected cycles from the most recent analysis. */
     private final List<List<Edge>> cycleAnalysisLoops = new ArrayList<>();
     /** Index of the currently highlighted cycle. */
@@ -207,6 +210,7 @@ public class GraphPanel extends JPanel {
                                 dragStart.clear();
                             }
                             selectedEdge = null;
+                            fireNodeSelection(hit);
                             repaint();
                         }
                     } else {
@@ -415,6 +419,34 @@ public class GraphPanel extends JPanel {
             translateY = e.getY() - factor * (e.getY() - translateY);
             repaint();
         });
+    }
+
+    /** Listener notified when a node is selected via mouse click. */
+    public interface NodeSelectionListener {
+        void nodeSelected(Node node);
+    }
+
+    /** Register a listener for node selection events. */
+    public void addNodeSelectionListener(NodeSelectionListener listener) {
+        if (listener != null && !nodeSelectionListeners.contains(listener)) {
+            nodeSelectionListeners.add(listener);
+        }
+    }
+
+    /** Remove a previously registered node selection listener. */
+    public void removeNodeSelectionListener(NodeSelectionListener listener) {
+        nodeSelectionListeners.remove(listener);
+    }
+
+    /** Notify listeners about a node selection. */
+    private void fireNodeSelection(Node node) {
+        if (nodeSelectionListeners.isEmpty()) {
+            return;
+        }
+        java.util.List<NodeSelectionListener> listeners = new ArrayList<>(nodeSelectionListeners);
+        for (NodeSelectionListener listener : listeners) {
+            listener.nodeSelected(node);
+        }
     }
 
     public void setPropertiesPanel(PropertiesPanel panel) {


### PR DESCRIPTION
## Summary
- add a Tools menu with a cycle analysis launcher and clear-analysis shortcut
- implement a cycle analysis dialog that lets users pick a start node, browse detected loops, and clear results
- extend GraphPanel with cycle detection, loop state management, and magenta edge highlighting for the active cycle

## Testing
- javac $(find src -name '*.java')

------
https://chatgpt.com/codex/tasks/task_e_68caa31e468c83249af11d2ed91c699f